### PR TITLE
Make colors configurable

### DIFF
--- a/src/angular-charts.js
+++ b/src/angular-charts.js
@@ -68,7 +68,8 @@ angular.module('angularCharts').directive('acChart', function($templateCache, $c
     chartContainer, 
     legendContainer, 
     chartType,
-    isAnimate =true;
+    isAnimate =true,
+    defaultColors = config.colors;
 
     /**
      * All the magic happens here
@@ -134,6 +135,7 @@ angular.module('angularCharts').directive('acChart', function($templateCache, $c
       points = data.data;
       if(scope.acConfig) {
         angular.extend(config, scope.acConfig);
+        config.colors = config.colors.concat(defaultColors);
       }
     }
 


### PR DESCRIPTION
I needed a way to change default colors and it seems that specifying it as a custom entry in config is the best way to do it currently.

The same could apply to `tooltip` styles, but I don't need that functionality yet.
