### PR TITLE
Bower fixes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,28 @@
 {
   "name": "angular-charts",
   "version": "0.0.1",
-  "main": "./dist/angular-charts.js"
+  "authors": [
+    "chinmaymk"
+  ],
+  "description": "angular directives for common charts using d3",
+  "keywords": [
+    "d3",
+    "charts",
+    "angular",
+    "angularjs"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "main": ["./dist/angular-charts.js"],
+  "dependencies": {
+    "d3": "~3.3.10",
+    "angular": "latest",
+    "jquery": "~2.0.3"
+  }
 }


### PR DESCRIPTION
Hello,

Bower would install this library without issue, but grunt wouldn't add it to the project using `grunt bower-install` because of the missing `main` field on the `bower.json` file. 

This fixes the issue.
