### PR TITLE
add tooltip to nicedata for bar chart

### DIFF
--- a/src/angular-charts.js
+++ b/src/angular-charts.js
@@ -187,7 +187,8 @@ angular.module('angularCharts').directive('acChart', function($templateCache, $c
           return {
             x : d.x,
             y : e,
-            s : i
+            s : i,
+            tooltip: angular.isArray(d.tooltip)?d.tooltip[i]:d.tooltip
           }
         })
       })


### PR DESCRIPTION
Support both string and array datatypes. Array datatype indexed to
series similar to y data. String datatype shows same tooltip regardless
of which bar fires mouseover.
