### PR TITLE
Better error handling when initializing without data

### DIFF
--- a/examples/main.controller.js
+++ b/examples/main.controller.js
@@ -1,27 +1,30 @@
 
 angular.module('example', ['angularCharts']);
 
-function MainController($scope) {
-	$scope.data = {
-		series: ['Sales', 'Income', 'Expense', 'Laptops', 'Keyboards'],
-		data : [{
-			x : "Sales",
-			y: [100,500, 0],
-			tooltip:"this is tooltip"
-		},
-		{
-			x : "Not Sales",
-			y: [300, 100, 100]
-		},
-		{
-			x : "Tax",
-			y: [351]
-		},
-		{
-			x : "Not Tax",
-			y: [54, 0, 879]
-		}]     
-	}
+function MainController($scope, $timeout) {
+	$timeout(function() {
+		$scope.data = {
+			series: ['Sales', 'Income', 'Expense', 'Laptops', 'Keyboards'],
+			data : [{
+				x : "Sales",
+				y: [100,500, 0],
+				tooltip:"this is tooltip"
+			},
+			{
+				x : "Not Sales",
+				y: [300, 100, 100]
+			},
+			{
+				x : "Tax",
+				y: [351]
+			},
+			{
+				x : "Not Tax",
+				y: [54, 0, 879]
+			}]     
+		};
+	}, 100);
+	
 
 	$scope.data1 = {
 		series: ['Sales', 'Income', 'Expense', 'Laptops', 'Keyboards'],

--- a/src/angular-charts.js
+++ b/src/angular-charts.js
@@ -133,8 +133,8 @@ angular.module('angularCharts').directive('acChart', function($templateCache, $c
     function prepareData() {
       data = scope.acData;
       chartType = scope.acChart;
-      series = data.series;
-      points = data.data;
+      series = (data) ? data.series || [] : [];
+      points = (data) ? data.data || [] : [];
       if(scope.acConfig) {
         angular.extend(config, scope.acConfig);
         config.colors = config.colors.concat(defaultColors);


### PR DESCRIPTION
Right now when initializing the map with a data coming from async source (like a JSON request) it throws an error when you initialize without data. This just makes sure that no errors are thrown.
