### PR TITLE
Update bower version to 0.2.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-charts",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "authors": [
     "chinmaymk"
   ],


### PR DESCRIPTION
The latest version on bower is 0.1.0 while I think it should be 0.2.2
