### PR TITLE
Remove x axis padding on area chart

### DIFF
--- a/src/angular-charts.js
+++ b/src/angular-charts.js
@@ -538,7 +538,7 @@ angular.module('angularCharts').directive('acChart', function($templateCache, $c
 
       var x = d3.scale.ordinal()
             .domain(points.map(function(d) { return d.x; }))
-            .rangeRoundBands([0, width]);
+            .rangePoints([0, width]);
 
       var y = d3.scale.linear()
           .range([height, 10]);


### PR DESCRIPTION
Great work on the module. Just providing a small change to prevent area charts from having padding on the x axis.

From this:
![screen shot 2014-06-21 at 17 07 44](https://cloud.githubusercontent.com/assets/2844580/3349355/5e59e99e-f95e-11e3-97fb-29042df45336.png)

To this:
![screen shot 2014-06-21 at 17 08 01](https://cloud.githubusercontent.com/assets/2844580/3349357/64d6f12c-f95e-11e3-9491-6efb6e7fbda8.png)
