### PR TITLE
Configure y-axis tick format from the config object

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ To run tests:
 * [jerjoham](https://github.com/jerjoham)
 * [soyuka](https://github.com/soyuka)
 * [jkleijn](https://github.com/jkleijn)
+* [chasd00](https://github.com/chasd00)
 
 License - MIT.
 

--- a/src/angular-charts.js
+++ b/src/angular-charts.js
@@ -83,7 +83,8 @@ angular.module('angularCharts').directive('acChart', function($templateCache, $c
       innerRadius: 0, // Only on pie Charts
       lineLegend: 'lineEnd', // Only on line Charts
       lineCurveType: 'cardinal',
-      isAnimate: true
+      isAnimate: true,
+      yAxisTickFormat: 's'
     };
 
     var totalWidth = element[0].clientWidth;
@@ -270,11 +271,12 @@ angular.module('angularCharts').directive('acChart', function($templateCache, $c
           .orient("bottom");
       filterXAxis(xAxis, x);
 
+      var tickFormat = config.yAxisTickFormat || 's';
       var yAxis = d3.svg.axis()
           .scale(y)
           .orient("left")
           .ticks(10)
-          .tickFormat(d3.format('s'));
+          .tickFormat(d3.format(tickFormat));
 
       /**
        * Start drawing the chart!
@@ -389,11 +391,12 @@ angular.module('angularCharts').directive('acChart', function($templateCache, $c
           .orient("bottom");
       filterXAxis(xAxis, x);
 
+      var tickFormat = config.yAxisTickFormat || 's';
       var yAxis = d3.svg.axis()
           .scale(y)
           .orient("left")
           .ticks(5)
-          .tickFormat(d3.format('s'));
+          .tickFormat(d3.format(tickFormat));
 
       var line = d3.svg.line()
           .interpolate(config.lineCurveType)
@@ -567,11 +570,12 @@ angular.module('angularCharts').directive('acChart', function($templateCache, $c
           .orient("bottom");
       filterXAxis(xAxis, x);
 
+      var tickFormat = config.yAxisTickFormat || 's';
       var yAxis = d3.svg.axis()
           .scale(y)
           .orient("left")
           .ticks(5)
-          .tickFormat(d3.format('s'));
+          .tickFormat(d3.format(tickFormat));
 
       d3.svg.line()
           .interpolate(config.lineCurveType)
@@ -776,11 +780,12 @@ angular.module('angularCharts').directive('acChart', function($templateCache, $c
           .orient("bottom");
       filterXAxis(xAxis, x);
 
+      var tickFormat = config.yAxisTickFormat || 's';
       var yAxis = d3.svg.axis()
           .scale(y)
           .orient("left")
           .ticks(5)
-          .tickFormat(d3.format('s'));
+          .tickFormat(d3.format(tickFormat));
 
       var yData = [0];
       var linedata = [];


### PR DESCRIPTION
You can now use standard D3 format strings for configuring the y-axis tick format with variable config.yAxisTickFormat. Defaults to 's' for backwards compatibility.

D3 format docs here:
https://github.com/mbostock/d3/wiki/Formatting#d3_format
