### PR TITLE
Memory Leak Fix

### DIFF
--- a/src/angular-charts.js
+++ b/src/angular-charts.js
@@ -183,7 +183,7 @@ angular.module('angularCharts').directive('acChart', function($templateCache, $c
       if(box.chartContainer == null && box.legendContainer == null){
         var container = $templateCache.get('angularChartsTemplate_' + config.legend.position);
         element.html(container); //http://stackoverflow.com/a/17883151
-        
+        $compile(element.contents())(scope);
 
         //getting children divs
         var childrens = element.find('div');
@@ -192,10 +192,9 @@ angular.module('angularCharts').directive('acChart', function($templateCache, $c
         box.height -= getChildrenByClassname(childrens, 'ac-title')[0].clientHeight;
       }else{
         d3.select(box.chartContainer[0]).selectAll('svg').remove();
-        d3.select(box.legendContainer[0]).selectAll('tr').remove();
       }
 
-      $compile(element.contents())(scope);
+      
     }
 
     /**


### PR DESCRIPTION
![angular-charts-memory-leak](https://cloud.githubusercontent.com/assets/7525348/4360630/aab85736-427d-11e4-843d-c7d5ffe1d891.JPG)

Issue #98 seems to be caused by the dom events still being attached to the detached elements

This fix skips rewriting the elements from the template and uses d3's remove function to remove the old chart, this destroys the events and allows the garbage collector to clean up 
