### PR TITLE
Fixes pie chart 0 value issues

### DIFF
--- a/src/angular-charts.js
+++ b/src/angular-charts.js
@@ -108,7 +108,7 @@ angular.module('angularCharts').directive('acChart', function($templateCache, $c
       width: 0,
       chartContainer: null,
       legendContainer: null,
-      yMaxData: 0,
+      yMaxData: null,
       legends: []
     };
 
@@ -216,9 +216,9 @@ angular.module('angularCharts').directive('acChart', function($templateCache, $c
      * Set yMaxData
      */
      function setYMaxData(){
-      scope.yMaxData = d3.max(points.map(function(d){
+      scope.yMaxData = (box.yMaxData == null) ? d3.max(points.map(function(d){
         return d.y.length;
-      }));
+      })) : box.yMaxData;
      }
 
     /**

--- a/src/provider.js
+++ b/src/provider.js
@@ -535,7 +535,7 @@
           domFunctions.removeToolTip(d, d3.event);
         })
         .on("mousemove", function(d) {
-          domFunctions.updateToolTip(d3.event);
+          domFunctions.updateToolTip(d, d3.event);
         })
         .on("click", function(d) {
           domFunctions.click(d, d3.event);
@@ -917,7 +917,9 @@
       });
 
     var path = svg.selectAll(".arc")
-      .data(pie(points))
+      .data(pie(points).filter(function (d){
+        return d.value > 0;
+      }))
       .enter().append("g");
 
     var complete = false;
@@ -995,12 +997,16 @@
   }], ['config', 'box', 'series', 'points', function (config, box, series, points){
       var service = this;
 
-      angular.forEach(points, function(value, key) {
+      var filteredPoints = points.filter(function (d){return d.y[0] > 0;});
+
+      angular.forEach(filteredPoints, function(value, key) {
         box.legends.push({
           color: config.colors[key],
           title: service.getBindableTextForLegend(config, value.x)
         });
       });
+
+      box.yMaxData = filteredPoints.length;
   }]);
 
   return service;


### PR DESCRIPTION
Fixes #143

Allows chart and legend functions to override scope.yMaxData by using box.yMaxData
Pie Chart skips 0 value data and skips legend entry
Pie chart legend now is not limited to max Y data count (self introduced bug)
