### PR TITLE
allow publishing to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 bower_components
 dist
 /.project
+.idea

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -89,13 +89,20 @@ module.exports = function(grunt) {
             }
           ]
         }
-      },
+      }
     },
     copy: {
       bowerPreRelease: {
         files: [
           { src: 'dist/angular-charts.js', dest: 'dist/angular-charts.tmp.js' },
           { src: 'dist/angular-charts.min.js', dest: 'dist/angular-charts.min.tmp.js' }
+        ]
+      },
+      npmPreRelease: {
+        files: [
+          { src: 'package.json', dest: 'dist/' },
+          { src: 'LICENSE', dest: 'dist/' },
+          { src: 'README.md', dest: 'dist/' }
         ]
       }
     },
@@ -109,6 +116,12 @@ module.exports = function(grunt) {
           "git commit -am 'release <%= pkg.version %>'",
           'git tag <%= pkg.version %>'
         ].join('&&')
+      },
+      npmRelease: {
+        command: [
+          'cd dist',
+          'npm publish'
+        ].join('&&')
       }
     }
   });
@@ -117,6 +130,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask('default', ['ngmin', 'htmlmin', 'html2js', 'csso', 'css2js', 'concat', 'uglify', 'clean', 'karma']);
   grunt.registerTask('release', ['karma', 'prompt', 'bowerValidateRelease']);
+  grunt.registerTask('publishToNpm', ['clean', 'concat', 'uglify', 'copy:npmPreRelease', 'shell:npmRelease']);
 
   grunt.registerTask('bowerValidateRelease', 'Make sure that we really want to release!', function() {
     if(grunt.config('release') === true) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.2.7",
   "description": "angular directives for common charts using d3, for more information visit",
   "main": "Gruntfile.js",
-  "dependencies": {},
+  "dependencies": {
+    "angular": ">=1.2.x",
+    "d3": "~3.3.10"
+  },
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-concat": "*",


### PR DESCRIPTION
More and more browser-based JavaScript libraries (including libraries that this project depends on - D3 & Angular) are moving to npm.  It would be excellent if angular-charts could do the same.  

I've updated package.json to reflect this project's runtime dependencies.

I also created a few new grunt tasks.  To publish a new version to npm, just run `grunt publishToNpm`.  This will clean, concat, uglify, then ensure the un-minified js, the minified js, the license file, and the readme are all included when publishing angular-charts to npm.
