### PR TITLE
Add ability to customize chart margins through config object

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,13 @@ Allowed values - `'pie', 'bar', 'line', 'point', 'area'`
   yAxisTickFormat: 's', //refer tickFormats in d3 to edit this value
   xAxisMaxTicks: 7, // Optional: maximum number of X axis ticks to show if data points exceed this number
   yAxisTickFormat: 's', // refer tickFormats in d3 to edit this value
-  waitForHeightAndWidth: false // if true, it will not throw an error when the height or width are not defined (e.g. while creating a modal form), and it will be keep watching for valid height and width values
+  waitForHeightAndWidth: false, // if true, it will not throw an error when the height or width are not defined (e.g. while creating a modal form), and it will be keep watching for valid height and width values
+  margin: { // Optional: If any margins are present they will override the default margins, expressed in pixels
+    top: 0,
+    left: 20,
+    bottom: 40,
+    right: 20
+  }
 };
 ```
 

--- a/src/angular-charts.js
+++ b/src/angular-charts.js
@@ -247,12 +247,13 @@ angular.module('angularCharts').directive('acChart', function($templateCache, $c
        * Setup date attributes
        * @type {Object}
        */
-      var margin = {
+      var margin = angular.extend({
         top: 0,
         right: 20,
         bottom: 30,
         left: 40
-      };
+      }, config.margin);
+
       width -= margin.left + margin.right;
       height -= margin.top + margin.bottom;
 
@@ -430,12 +431,13 @@ angular.module('angularCharts').directive('acChart', function($templateCache, $c
      * @return {[type]} [description]
      */
     function lineChart() {
-      var margin = {
+      var margin = angular.extend({
         top: 0,
         right: 40,
         bottom: 20,
         left: 40
-      };
+      }, config.margin);
+      
       width -= margin.left + margin.right;
       height -= margin.top + margin.bottom;
 
@@ -655,12 +657,13 @@ angular.module('angularCharts').directive('acChart', function($templateCache, $c
      * @return {[type]} [description]
      */
     function areaChart() {
-      var margin = {
+      var margin = angular.extend({
         top: 0,
         right: 40,
         bottom: 20,
         left: 40
-      };
+      }, config.margin);
+
       width -= margin.left + margin.right;
       height -= margin.top + margin.bottom;
 
@@ -903,12 +906,13 @@ angular.module('angularCharts').directive('acChart', function($templateCache, $c
 
 
     function pointChart() {
-      var margin = {
+      var margin = angular.extend({
         top: 0,
         right: 40,
         bottom: 20,
         left: 40
-      };
+      }, config.margin);
+
       width -= margin.left - margin.right;
       height -= margin.top - margin.bottom;
 


### PR DESCRIPTION
Adds the ability to override the default margins of the chart via the ac-config object. Fixes an issue I had using the chart where the y-axis would go from 0-100k and the 1 in the 100k was cut off. This change allowed me to add some extra margin to the left to compensate, only on the charts where it was necessary.