### PR TITLE
removing duplicated line

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ Allowed values - `'pie', 'bar', 'line', 'point', 'area'`
   isAnimate: true, // run animations while rendering chart
   yAxisTickFormat: 's', //refer tickFormats in d3 to edit this value
   xAxisMaxTicks: 7, // Optional: maximum number of X axis ticks to show if data points exceed this number
-  yAxisTickFormat: 's', // refer tickFormats in d3 to edit this value
   waitForHeightAndWidth: false // if true, it will not throw an error when the height or width are not defined (e.g. while creating a modal form), and it will be keep watching for valid height and width values
 };
 ```


### PR DESCRIPTION
the line documentation for `yAxisTickFormat ` property was removed because it was duplicated